### PR TITLE
Small README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ This gem provides a tiny HMAC implementation along with a warden strategy to us 
 ## HMAC usage
 
     h = HMAC.new('secret', 'md5')
-    h.generate_signature('http://example.com/')
+    h.generate_signature('http://example.com/?foo=bar')
     
 If you want to generate the signature for a signed URL, pass the parameter used for the token:
 
     h = HMAC.new('secret', 'md5')
-    h.generate_signature('http://example.com/?token=123', 'token')
+    h.generate_signature('http://example.com/?foo=bar&token=123', 'token')
     
 ## Warden strategy usage
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Configure the HMAC warden strategy:
     end
 
 `params` allows you to specify parameters the request must contain, `token` is the name of the token parameter, `secret` and `algorithm` allow you to specify
-the secret and algorithm used for the HMAC algorithm. `hmac` expects a class that implement the HMAC algorithm. It is instantiated on each request.
+the secret and algorithm used for the HMAC algorithm. `hmac` expects a class that implements the HMAC algorithm. It is instantiated on each request.
 
 If you want to retrieve the secret and token using a different strategy, extend the HMAC strategy:
 


### PR DESCRIPTION
You should actually get some fancy results when trying out the example code. 

```
ruby-1.9.2-p180 :002 > h.generate_signature('http://example.com/')
 => false 
```

So I would prefer: 

```
ruby-1.9.2-p180 :003 > h.generate_signature('http://example.com/?foo=bar')
 => "0838560c6db45c0ce6c01c61141dc98b" 
```

:-)
