### PR TITLE
Pass method and headers properly in Faraday middleware

### DIFF
--- a/lib/faraday/request/hmac.rb
+++ b/lib/faraday/request/hmac.rb
@@ -3,7 +3,7 @@ require 'hmac/signer'
 
 module Faraday
   class Request::Hmac < Faraday::Middleware
-      
+
     # create a new Hmac middleware instance
     #
     # @param [Object] app           The url of the request
@@ -13,7 +13,7 @@ module Faraday
     # @option options [String]             :nonce ('')           The nonce to use in the signature
     # @option options [String, #strftime]  :date (Time.now)      The date to use in the signature
     # @option options [Hash]               :headers ({})         A list of optional headers to include in the signature
-    #                       
+    #
     # @option options [String]             :auth_scheme ('HMAC')   The name of the authorization scheme used in the Authorization header and to construct various header-names
     # @option options [String]             :auth_param ('auth')   The name of the authentication param to use for query based authentication
     # @option options [Hash]               :extra_auth_params ({}) Additional parameters to inject in the auth parameter. This parameter is ignored unless :query_based evaluates to true.
@@ -27,21 +27,22 @@ module Faraday
     def initialize(app, secret, options = {})
       @app, @secret, @options, @query_values = app, secret, options
     end
-  
+
     def call(env)
       sign(env)
       @app.call(env)
     end
-  
+
     def sign(env)
       signer = HMAC::Signer.new
       url = env[:url]
-      headers, url = *signer.sign_request(url, @secret, @options)
-        
+      method = env[:method]
+      headers, url = *signer.sign_request(url, @secret, @options.merge(:method => env[:method]))
+
       env[:request_headers] = (env[:request_headers] || {}).merge(headers)
       env[:url] = URI.parse(url)
       env
     end
-      
+
   end
 end

--- a/test/faraday/request/hmac_test.rb
+++ b/test/faraday/request/hmac_test.rb
@@ -1,5 +1,6 @@
 require 'faraday'
 require 'faraday/request/hmac'
+require 'riot/rr'
 
 class DummyApp
   attr_accessor :env
@@ -15,36 +16,36 @@ end
 
 
 context "the faraday middleware" do
-  
+
   setup do
     Timecop.freeze Time.gm(2011, 7, 1, 20, 28, 55)
   end
-  
+
   teardown do
     Timecop.return
   end
-  
+
   context "> using header-based auth" do
     setup do
       m = Faraday::Request::Hmac.new(DummyApp.new, "testsecret")
       m.call({ :request_headers => {}, :url => 'http://www.example.com' })
     end
-  
+
     asserts("authorization header") {topic[:request_headers]["Authorization"]}.equals("HMAC 539263f4f83878a4917d2f9c1521320c28b926a9")
     asserts("date header") {topic[:request_headers]["Date"]}.equals("Fri,  1 Jul 2011 20:28:55 GMT")
     asserts("query values") {topic[:url].query}.nil
-    
+
     context "> using a different auth header format" do
       setup do
         m = Faraday::Request::Hmac.new(DummyApp.new, "testsecret", {:auth_key => 'TESTKEYID', :auth_header_format => '%{auth_scheme} %{auth_key} %{signature}'})
         m.call({ :request_headers => {}, :url => 'http://www.example.com' })
       end
-  
+
       asserts("authorization header") {topic[:request_headers]["Authorization"]}.equals("HMAC TESTKEYID 539263f4f83878a4917d2f9c1521320c28b926a9")
       asserts("date header") {topic[:request_headers]["Date"]}.equals("Fri,  1 Jul 2011 20:28:55 GMT")
       asserts("query values") {topic[:url].query}.nil
     end
-    
+
   end
 
   context "> using query-based auth" do
@@ -52,21 +53,21 @@ context "the faraday middleware" do
       m = Faraday::Request::Hmac.new(DummyApp.new, "testsecret", {:query_based => true, :extra_auth_params => {"auth_key" => "TESTKEYID"}})
       m.call({ :request_headers => {}, :url => 'http://www.example.com' })
     end
-  
+
     asserts("authorization header") {topic[:request_headers]["Authorization"]}.nil
     asserts("date header") {topic[:request_headers]["Date"]}.nil
-    
+
     context "> query values" do
-      
+
       setup do
         Rack::Utils.parse_nested_query(topic[:url].query)
       end
-    
+
       asserts("auth date") {topic["auth"]["date"]}.equals("Fri,  1 Jul 2011 20:28:55 GMT")
       asserts("auth_key") {topic["auth"]["auth_key"]}.equals("TESTKEYID")
       asserts("auth signature") {topic["auth"]["signature"]}.equals("539263f4f83878a4917d2f9c1521320c28b926a9")
     end
-    
+
   end
 
 
@@ -74,16 +75,32 @@ context "the faraday middleware" do
     setup do
       con = Faraday.new(:url => "http://example.com/") do |builder|
         builder.headers['X-Public-Key'] = 'TESTPUBLIC'
+        builder.headers['Content-MD5'] = '539263f4f83878a4917d2f9c1521320c28b926a9'
+
         builder.use Faraday::Request::Hmac, 'TESTKEYID'
         builder.adapter :test do |stub|
           stub.get('/') do |env|
+            [200, {}, ""]
+          end
+
+          stub.post('/') do |env|
             [200, {}, ""]
           end
         end
       end
     end
 
-    asserts("Not Raise Exeption") {topic.get('/')}
+    asserts("does not raise exeption") { topic.get('/') }
+    asserts("passes method properly") {
+      representation = nil
+      any_instance_of(HMAC::Signer) do |signer|
+        proxy(signer).canonical_representation do |r|
+          representation = r
+        end
+      end
+      topic.post('/')
+      representation[0, 4] == 'POST'
+    }
   end
 
 end


### PR DESCRIPTION
Before all Faraday requests generated canonical representation with GET request method, even if it was a POST request.
