### PR TITLE
Prevent timing side channel attack.

### DIFF
--- a/lib/hmac/signer.rb
+++ b/lib/hmac/signer.rb
@@ -268,13 +268,13 @@ module HMAC
     end
 
     private
-    
+
     # compares two hashes in a manner that's invulnerable to timing sidechannel attacks (see issue #16)
     # by comparing them characterwise up to the end in all cases, no matter where the mismatch happens
     # short circuits if the length does not match since this does not allow timing sidechannel attacks.
     def compare_hashes(presented, computed)
       if computed.length == presented.length then
-        computed.chars.zip(presented.chars).map {|x,y| x == y}.all?
+        computed.chars.zip(presented.chars).inject(true) { |value, (x,y)| value && (x == y) }
       else
         false
       end


### PR DESCRIPTION
As per #16 not only is '==' lazy and short circuits, but so is `all?` and `any?`
so the previous fix won't work for padded attacks (where the string length is
padding during a brute force). This refactoring uses inject which will always
iterate over all the characters.

See https://gist.github.com/JonRowe/6437213

/ht @samphippen for the check
