### PR TITLE
Allow non-GET query based HMAC verification

### DIFF
--- a/lib/hmac/signer.rb
+++ b/lib/hmac/signer.rb
@@ -117,6 +117,7 @@ module HMAC
     #
     # @return [Bool] true if the signature is valid
     def validate_url_signature(url, secret, opts = {})
+      method = opts.delete(:method) {|_| "GET"}
       opts = default_opts.merge(opts)
       opts[:query_based] = true
 
@@ -129,7 +130,7 @@ module HMAC
 
       date = auth_params["date"]
       nonce = auth_params["nonce"]
-      validate_signature(auth_params["signature"], :secret => secret, :method => "GET", :path => uri.path, :date => date, :nonce => nonce, :query => query_values, :headers => {})
+      validate_signature(auth_params["signature"], :secret => secret, :method => method, :path => uri.path, :date => date, :nonce => nonce, :query => query_values, :headers => {})
     end
 
     # generates the canonical representation for a given request
@@ -268,7 +269,7 @@ module HMAC
     end
 
     private
-    
+
     # compares two hashes in a manner that's invulnerable to timing sidechannel attacks (see issue #16)
     # by comparing them characterwise up to the end in all cases, no matter where the mismatch happens
     # short circuits if the length does not match since this does not allow timing sidechannel attacks.

--- a/lib/hmac/strategies/query.rb
+++ b/lib/hmac/strategies/query.rb
@@ -8,7 +8,7 @@ module Warden
       #
       # @author Felix Gilcher <felix.gilcher@asquera.de>
       class Warden::Strategies::HMAC::Query < Warden::Strategies::HMAC::Base
-  
+
         # Checks that this strategy applies. Tests that the required
         # authentication information was given.
         #
@@ -20,42 +20,42 @@ module Warden
           valid = valid && has_nonce? if nonce_required?
           valid
         end
-        
+
         # Checks that the request contains a signature
         #
         # @return [Bool] true if the request contains a signature
         def has_signature?
           auth_info.include? "signature"
         end
-        
+
         # Check that the signature given in the request is valid.
         #
         # @return [Bool] true if the request is valid
         def signature_valid?
-          hmac.validate_url_signature(request.url, secret)
+          hmac.validate_url_signature(request.url, secret, :method => request_method)
         end
-  
+
         # retrieve the authentication information from the request
         #
         # @return [Hash] the authentication info in the request
         def auth_info
           params[auth_param] || {}
         end
-  
+
         # retrieve the nonce from the request
         #
         # @return [String] The nonce or an empty string if no nonce was given in the request
         def nonce
           auth_info["nonce"] || ""
         end
-  
+
         # retrieve the request timestamp as string
         #
         # @return [String] The request timestamp or an empty string if no timestamp was given in the request
         def request_timestamp
           auth_info["date"] || ""
         end
-      
+
       end
     end
   end


### PR DESCRIPTION
We should not assume the request method is GET when verifying the HMAC
signature of a query-based authorization. Especially not when the
provided Faraday middleware specifically sets the method to the request
method when generating the signature to send with the request. This
prevented any non-GET requests from being validated.
