### PR TITLE
Add Rails logger check

### DIFF
--- a/lib/hmac/strategies/base.rb
+++ b/lib/hmac/strategies/base.rb
@@ -88,6 +88,8 @@ module Warden
         def logger
           if defined? Padrino
             Padrino.logger
+          elsif defined? Rails
+            Rails.logger
           end
         end
   


### PR DESCRIPTION
If `Rails` is defined, use the Rails logger.
